### PR TITLE
First try at FORTIFY function annotation

### DIFF
--- a/modules/annotate.py
+++ b/modules/annotate.py
@@ -69,4 +69,4 @@ def run_plugin(bv, function):
               comment = "arg{}: {}\n".format(idx+1, function_arg)
               function.set_comment(stack_instruction.address, comment)
             except StopIteration:
-              log_error('[x] Virtual Stack Empty. Unable to find function arguments for <{}>'.format(callee_name))
+              log_error('[x] Virtual Stack Empty. Unable to find function arguments for <{}>'.format(callee.name))

--- a/modules/annotate.py
+++ b/modules/annotate.py
@@ -56,9 +56,11 @@ def run_plugin(bv, function):
         callee_name = callee.name
         imported = callee.symbol.type == SymbolType.ImportedFunctionSymbol
         db_has_key = db.has_key(callee_name)
-        if not db_has_key and callee_name.endswith("_chk") and callee_name.startswith("__") and len(callee_name) > 6:
-            db_has_key = db.has_key(callee_name[2:-4])
-            callee_name = callee_name[2:-4]
+
+        # if name isn't found, try the un- FORTIFY -ed name, if possible
+        if not db_has_key and "_chk" in callee_name and callee_name.startswith("__") and len(callee_name) > 6:
+            callee_name = callee_name[2:callee_name.find("_chk")]
+            db_has_key = db.has_key(callee_name)
 
         if (imported and db_has_key):
           stack_args = iter(stack)


### PR DESCRIPTION
Fixes #4 

The FORTIFY_SOURCE feature in glibc mangles symbol names of buffer-related, and format string functions, as it does its checks. The checking it does has no effect on how the function is intended to be called, therefore, the parameter types and names are the same. To add these functions to the annotator, we could manually duplicate each entry by hand in data/all_functions.json, but that would be tedious. A quick runtime check for mangled names should suffice, and detect more functions.

It was difficult to find any definitive documentation on how exactly names are mangled, but it seems that there is at least a heuristic we can try to catch most of it.

Take `strncpy` for example. Most times this will become `__strncpy_chk` after FORTIFY mangles it, but sometimes it will be `__strncpy_chk2` (I think this is when the src size is known at compile-time). To check both, I just cut out the name up to the first "_chk".

In this patch, the original symbol name is checked in the database first. Only if it's not found, will it then check for post FORTIFY names. Therefore this patch shouldn't mess with previous detection rates, only increase them.

[This article](https://android-developers.googleblog.com/2017/04/fortify-in-android.html) indicates that there also may be another mangled name that FORTIFY can output `__memset_real`, in their example. My patch doesn't address this however as I haven't seen it in the wild yet.


As the title of the PR implies, this is my first try at a fix, so please let me know if you have suggestions :)